### PR TITLE
Language switcher

### DIFF
--- a/design/designitalia/templates/header/service.tpl
+++ b/design/designitalia/templates/header/service.tpl
@@ -6,7 +6,10 @@
             <a href="{openpaini('InstanceSettings','UrlAmministrazioneAfferente', '#')}">
                 <span>{openpaini('InstanceSettings','NomeAmministrazioneAfferente', 'Provincia autonoma di Trento')}</span>
             </a>
-            {* Blocco multilingua, non utilizzato per ora
+
+            {include uri='design:page_header_languages.tpl'}
+
+          {* Blocco multilingua, non utilizzato per ora
             <div class="Header-languages">
                 <a class="Header-language is-active u-hidden u-md-inlineBlock u-lg-inlineBlock" href="" title="sito in italiano">
                     <abbr title="Italiano">ITA</abbr>
@@ -36,7 +39,7 @@
                     </ul>
                 </div>
             </div>
-            *}
+*}
         </div>
     </div>
 {/if}

--- a/design/designitalia/templates/page_header_languages.tpl
+++ b/design/designitalia/templates/page_header_languages.tpl
@@ -1,0 +1,35 @@
+{def $lang_selector = array()
+     $avail_translation = array()}
+{if and( is_set( $DesignKeys:used.url_alias ), $DesignKeys:used.url_alias|count|ge( 1 ) )}
+    {set $avail_translation = language_switcher( $DesignKeys:used.url_alias )}
+{else}
+    {set $avail_translation = language_switcher( $site.uri.original_uri )}
+{/if}
+
+
+{if $avail_translation|count|gt( 1 )}
+
+    {foreach $avail_translation as $siteaccess => $lang}
+    {if is_set($lang.locale)}
+      {append-block variable=$lang_selector}
+        {if $siteaccess|eq( $access_type.name )}
+          <a class="Header-language is-active u-hidden u-md-inlineBlock u-lg-inlineBlock" title="{$lang.text|wash|upcase}" href={$lang.url|ezurl}>
+            {$lang.text|wash|upcase}
+          </a>
+        {else}
+          <a class="Header-language u-hidden u-md-inlineBlock u-lg-inlineBlock" title="{$lang.text|wash|upcase}" href={$lang.url|ezurl} lang="{$lang.locale|extract_right(2)|downcase}">
+            {$lang.text|wash|upcase}
+          </li>
+
+        {/if}
+        {/append-block}
+    {/if}
+    {/foreach}
+
+
+  <div class="Header-languages">
+    {$lang_selector|implode( '' )}
+  </div>
+
+{/if}
+{undef $lang_selector}


### PR DESCRIPTION
implementazione del language switcher. Attualmente gestisce tutta la lista di lingue in orizzontale nel menu in alto (service). Le lingue devono essere inserite nel file site.ini [RegionalSettings] TranslationSA[nome_siteaccess]=nome_lingua