### PR TITLE
navigazione di area tematica

### DIFF
--- a/design/designitalia/templates/footer/contacts_list.tpl
+++ b/design/designitalia/templates/footer/contacts_list.tpl
@@ -1,49 +1,49 @@
 <ul>
-    {if is_set($pagedata.contacts.indirizzo)}
+    {if is_set($contacts.indirizzo)}
         <li>
             <i class="fa fa-building u-textClean"></i>
-            <a href="http://maps.google.com/maps?q={$pagedata.contacts.indirizzo|urlencode}">
-                {$pagedata.contacts.indirizzo}
+            <a href="http://maps.google.com/maps?q={$contacts.indirizzo|urlencode}">
+                {$contacts.indirizzo}
             </a>
         </li>
     {/if}
 
-    {if is_set($pagedata.contacts.telefono)}
+    {if is_set($contacts.telefono)}
         <li>
-            {def $tel = strReplace($pagedata.contacts.telefono,array(" ",""))}
-            {*        <a href="tel:{$pagedata.contacts.telefono}">*}
+            {def $tel = strReplace($contacts.telefono,array(" ",""))}
+            {*        <a href="tel:{$contacts.telefono}">*}
             <i class="fa fa-phone-square u-textClean"></i>
             <a class="u-linkClean" href="tel:{$tel}">
-                {$pagedata.contacts.telefono}
+                {$contacts.telefono}
             </a>
         </li>
     {/if}
-    {if is_set($pagedata.contacts.fax)}
+    {if is_set($contacts.fax)}
         <li>
-            {def $fax = strReplace($pagedata.contacts.fax,array(" ",""))}
-            {*      <a href="tel:{$pagedata.contacts.fax}">*}
+            {def $fax = strReplace($contacts.fax,array(" ",""))}
+            {*      <a href="tel:{$contacts.fax}">*}
             <i class="fa fa-fax u-textClean"></i>
             <a class="u-linkClean" href="tel:{$fax}">
-                {$pagedata.contacts.fax}
+                {$contacts.fax}
             </a>
         </li>
     {/if}
-    {if is_set($pagedata.contacts.email)}
+    {if is_set($contacts.email)}
         <li><i class="fa fa-envelope-o u-textClean"></i>
-            <a class="u-linkClean" href="mailto:{$pagedata.contacts.email}">
-                {$pagedata.contacts.email}
+            <a class="u-linkClean" href="mailto:{$contacts.email}">
+                {$contacts.email}
             </a></li>
     {/if}
-    {if is_set($pagedata.contacts.pec)}
+    {if is_set($contacts.pec)}
         <li><i class="fa fa-envelope u-textClean"></i>
-            <a class="u-linkClean" href="mailto:{$pagedata.contacts.pec}">
-                 {$pagedata.contacts.pec}
+            <a class="u-linkClean" href="mailto:{$contacts.pec}">
+                 {$contacts.pec}
             </a></li>
     {/if}
-    {if is_set($pagedata.contacts.web)}
+    {if is_set($contacts.web)}
         <li><i class="fa fa-link u-textClean"></i>
-            <a class="u-linkClean" href="{$pagedata.contacts.web}">
-                 {def $pnkParts = $pagedata.contacts.web|explode('//')}{if is_set( $pnkParts[1] )}{$pnkParts[1]}{/if}
+            <a class="u-linkClean" href="{$contacts.web}">
+                 {def $pnkParts = $contacts.web|explode('//')}{if is_set( $pnkParts[1] )}{$pnkParts[1]}{/if}
             </a></li>
     {/if}
 </ul>

--- a/design/designitalia/templates/header/logo.tpl
+++ b/design/designitalia/templates/header/logo.tpl
@@ -1,11 +1,23 @@
-{def $is_only_logo = cond(and( $pagedata.homepage|has_attribute('only_logo'), $pagedata.homepage|attribute('only_logo').data_int|eq(1) ), true(), false())}
+{def $is_only_logo = cond(and( $pagedata.homepage|has_attribute('only_logo'), $pagedata.homepage|attribute('only_logo').data_int|eq(1) ), true(), false())
+     $logo_url = cond(and( is_set($pagedata.header.logo.url), $pagedata.header.logo.url), $pagedata.header.logo.url, false())
+     $site_name = cond( $pagedata.homepage|has_attribute('site_name'), $pagedata.homepage|attribute('site_name').content|wash(), ezini('SiteSettings','SiteName'))
+     $site_url = "/"|ezurl(no)
+     $site_slug = false()
+     $is_area_tematica = is_area_tematica()}
+
+{if and($is_area_tematica, $is_area_tematica|has_attribute('logo'))}
+    {set $is_only_logo = cond(and( $is_area_tematica|has_attribute('only_logo'), $is_area_tematica|attribute('only_logo').data_int|eq(1) ), true(), false())
+         $logo_url = $is_area_tematica|attribute('logo').content.header_logo.url
+         $site_name = $is_area_tematica.name|wash()
+         $site_url = $is_area_tematica.url_alias|ezurl(no)}
+{/if}
 <div class="Header-logo Grid-cell" aria-hidden="true">
     {if $is_only_logo}
-        <h1 alt="{ezini('SiteSettings','SiteName')}">
+        <h1 alt="{$site_name}">
     {/if}
-    <a href="/" tabindex="-1">
-        {if and( is_set($pagedata.header.logo.url), $pagedata.header.logo.url)}
-            <img src="{$pagedata.header.logo.url|ezroot(no)}" alt="{ezini('SiteSettings','SiteName')}" {if $is_only_logo}style="width: auto;"{/if}/>
+    <a href="{$site_url}" tabindex="-1">
+        {if $logo_url}
+            <img src="{$logo_url|ezroot(no)}" alt="{$site_name}" {if $is_only_logo}style="width: auto;"{/if}/>
         {/if}
     </a>
     {if $is_only_logo}
@@ -18,11 +30,13 @@
 {else}
     <div class="Header-title Grid-cell">
         <h1 class="Header-titleLink">
-            <a accesskey="1" href="{"/"|ezurl(no)}">
-                {ezini('SiteSettings','SiteName')}{*<br>
-                <small>eventuale sottotitolo</small>*}
+            <a accesskey="1" href="{$site_url}">
+                {$site_name}
+                {if $site_slug}
+                <br><small>{$site_slug}</small>
+                {/if}
             </a>
         </h1>
     </div>
 {/if}
-{undef $is_only_logo}
+{undef $is_only_logo $logo_url $site_name $site_url $site_slug $is_area_tematica}

--- a/design/designitalia/templates/header/service.tpl
+++ b/design/designitalia/templates/header/service.tpl
@@ -1,14 +1,34 @@
-{def $header_service = openpaini('GeneralSettings','header_service', 1)}
-
+{def $header_service = openpaini('GeneralSettings','header_service', 1)
+	 $header_service_list = array()
+	 $is_area_tematica = is_area_tematica()}
 {if $header_service|eq(1)}
-    <div class="Header-banner">
+	{set $header_service_list = $header_service_list|append(hash(
+		'url', openpaini('InstanceSettings','UrlAmministrazioneAfferente', '#'),
+		'name', openpaini('InstanceSettings','NomeAmministrazioneAfferente', 'Provincia autonoma di Trento')
+	))}    
+{/if}
+{if and($is_area_tematica, $is_area_tematica|has_attribute('logo'))}
+	{set $header_service_list = $header_service_list|append(hash(
+		'url', "/"|ezurl(no),
+		'name', cond( $pagedata.homepage|has_attribute('site_name'), $pagedata.homepage|attribute('site_name').content|wash(), ezini('SiteSettings','SiteName'))
+	))}    
+{/if}
+
+{if $header_service_list|count()|gt(0)}
+<div class="Header-banner">
         <div class="Header-owner Headroom-hideme">
-            <a href="{openpaini('InstanceSettings','UrlAmministrazioneAfferente', '#')}">
-                <span>{openpaini('InstanceSettings','NomeAmministrazioneAfferente', 'Provincia autonoma di Trento')}</span>
-            </a>
+            {foreach $header_service_list as $item}
+	            <div class="Breadcrumb-item">
+		            <a class="Breadcrumb-link u-color-white" href="{$item.url}">
+		                <span>{$item.name|wash()}</span>
+		            </a>	
+	            </div>
+            {/if}
 
             {include uri='design:header/languages.tpl'}
 
         </div>
     </div>
 {/if}
+
+{undef $header_service $header_service_list $is_area_tematica}

--- a/design/designitalia/templates/menu/header_menu.tpl
+++ b/design/designitalia/templates/menu/header_menu.tpl
@@ -1,6 +1,14 @@
 {if and( $pagedata.is_login_page|not(), array( 'edit', 'browse' )|contains( $ui_context )|not(), openpaini( 'TopMenu', 'ShowMegaMenu', 'enabled' )|eq('enabled') )}
 
-{def $top_menu_node_ids = openpaini( 'TopMenu', 'NodiCustomMenu', array() )}
+{def $is_area_tematica = is_area_tematica()}
+{if and($is_area_tematica, $is_area_tematica|has_attribute('link_al_menu_orizzontale'))}
+    {def $top_menu_node_ids = array()}
+    {foreach $is_area_tematica|attribute('link_al_menu_orizzontale').content.relation_list as $item}
+        {set $top_menu_node_ids = $top_menu_node_ids|append($item.node_id)}
+    {/foreach}
+{else}
+    {def $top_menu_node_ids = openpaini( 'TopMenu', 'NodiCustomMenu', array() )}
+{/if}
 {def $top_menu_node_ids_count = $top_menu_node_ids|count()}
 
 {def $main_styles = openpaini( 'Stili', 'Nodo_NomeStile', array() )}
@@ -75,4 +83,5 @@
         </ul>
     </nav>
 </div>
+{undef $is_area_tematica}
 {/if}

--- a/design/designitalia/templates/menu/offcanvas_menu.tpl
+++ b/design/designitalia/templates/menu/offcanvas_menu.tpl
@@ -1,4 +1,12 @@
-{def $top_menu_node_ids = openpaini( 'TopMenu', 'NodiCustomMenu', array() )}
+{def $is_area_tematica = is_area_tematica()}
+{if and($is_area_tematica, $is_area_tematica|has_attribute('link_al_menu_orizzontale'))}
+    {def $top_menu_node_ids = array()}
+    {foreach $is_area_tematica|attribute('link_al_menu_orizzontale').content.relation_list as $item}
+        {set $top_menu_node_ids = $top_menu_node_ids|append($item.node_id)}
+    {/foreach}
+{else}
+    {def $top_menu_node_ids = openpaini( 'TopMenu', 'NodiCustomMenu', array() )}
+{/if}
 {def $top_menu_node_ids_count = $top_menu_node_ids|count()}
 
 {def $main_styles = openpaini( 'Stili', 'Nodo_NomeStile', array() )}
@@ -92,3 +100,4 @@
         </nav>
     </div>
 </section>
+{undef $is_area_tematica}

--- a/design/designitalia/templates/page_footer.tpl
+++ b/design/designitalia/templates/page_footer.tpl
@@ -1,11 +1,25 @@
+{def $is_area_tematica = is_area_tematica()}
 {def $footerBlocks = 4
      $has_notes = false()
      $has_contacts = false()
      $has_links  = false()
-     $has_social  = false()
-     $footer_notes = fetch( 'openpa', 'footer_notes' )
-     $footer_links = fetch( 'openpa', 'footer_links' )
+     $has_social  = false()     
      $footerBlocksClass = 'u-sizeFull'}
+
+{if and($is_area_tematica, $is_area_tematica|has_attribute('link'))}
+    {def $footer_links = array()}
+    {foreach $is_area_tematica|attribute('link').content.relation_list as $item}
+        {set $footer_links = $footer_links|append(fetch(content, node, hash(node_id, $item.node_id)))}
+    {/foreach}
+{else}
+    {def $footer_links = fetch( 'openpa', 'footer_links' )}
+{/if}
+
+{if and($is_area_tematica, $is_area_tematica|has_attribute('note_footer'))}
+    {def $footer_notes = $is_area_tematica|attribute('note_footer')}
+{else}
+    {def $footer_notes = fetch( 'openpa', 'footer_notes' )}
+{/if}
 
 {if count( $footer_notes )|gt(0)}
     {set $has_notes = true()}
@@ -13,14 +27,20 @@
     {set $footerBlocks = $footerBlocks|sub(1)}
 {/if}
 
-{if or(is_set($pagedata.contacts.indirizzo), is_set($pagedata.contacts.telefono), is_set($pagedata.contacts.fax),
-       is_set($pagedata.contacts.email), is_set($pagedata.contacts.pec), is_set($pagedata.contacts.web))}
+{if and($is_area_tematica, $is_area_tematica|has_attribute('contacts'))}
+    {def $contacts = parse_contacts_matrix($is_area_tematica)}
+{else}
+    {def $contacts = $pagedata.contacts}
+{/if}
+
+{if or(is_set($contacts.indirizzo), is_set($contacts.telefono), is_set($contacts.fax),
+       is_set($contacts.email), is_set($contacts.pec), is_set($contacts.web))}
     {set $has_contacts = true()}
 {else}
     {set $footerBlocks = $footerBlocks|sub(1)}
 {/if}
 
-{if or(is_set($pagedata.contacts.facebook), is_set($pagedata.contacts.twitter), is_set($pagedata.contacts.linkedin), is_set($pagedata.contacts.instagram))}
+{if or(is_set($contacts.facebook), is_set($contacts.twitter), is_set($contacts.linkedin), is_set($contacts.instagram))}
     {set $has_social = true()}
 {else}
     {set $footerBlocks = $footerBlocks|sub(1)}
@@ -88,7 +108,7 @@
             {if $has_contacts}
                 <div class="Footer-block Grid-cell {$footerBlocksClass}">
                     <h2 class="Footer-blockTitle">Contatti</h2>
-                    {include uri='design:footer/contacts_list.tpl'}
+                    {include uri='design:footer/contacts_list.tpl' contacts=$contacts}
                 </div>
             {/if}
 

--- a/doc/features/area_tematica.md
+++ b/doc/features/area_tematica.md
@@ -1,0 +1,14 @@
+#Area tematica
+
+Sono considerate aree tematiche gli oggetti di classe comprese nell'array ```openpa.ini [AreeTematiche] IdentificatoreAreaTematica```
+
+Un area tematica può:
+ * sovrascrivere il logo e il nome del sito se esiste ed è popolato l'attributo __Logo (logo) ezimage__
+ * mostare solo il logo senza il nome del sito se esiste ed è popolato l'attributo __Mostra solo il logo in intestazione (only_logo) ezboolean__ 
+ * sovrascrivere il menu principale del sito se esiste ed è popolato l'attributo __Link al menu orizzontale (link_al_menu_orizzontale) ezobjectrelationlist__
+ * sovrascrivere l'elenco dei contatti nel footer del sito se esiste ed è popolato l'attributo __Contatti (contacts) ezmatrix__ (richiede openpa-ls >= 2.22)
+ * sovrascrivere l'elenco dei link nel footer del sito se esiste ed è popolato l'attributo __Link nel footer (link) ezobjectrelationlist__
+ * sovrascrivere le note del footer del sito se esiste ed è popolato l'attributo __Note per il footer (note_footer) ezxmlblock__
+
+Note:
+ * se viene impostato il logo di area, il nome del sito compare nella barra in alto (vedi /design/designitalia/templates/header/service.tpl) e non viene sovrascritto il logo del footer


### PR DESCRIPTION
Un area tematica può:

 * sovrascrivere il logo e il nome del sito se esiste ed è popolato l'attributo Logo (logo) ezimage
 * mostare solo il logo senza il nome del sito se esiste ed è popolato l'attributo Mostra solo il logo in intestazione (only_logo) ezboolean
 * sovrascrivere il menu principale del sito se esiste ed è popolato l'attributo Link al menu orizzontale (link_al_menu_orizzontale) ezobjectrelationlist
 * sovrascrivere l'elenco dei contatti nel footer del sito se esiste ed è popolato l'attributo Contatti (contacts) ezmatrix (richiede openpa-ls >= 2.22)
 * sovrascrivere l'elenco dei link nel footer del sito se esiste ed è popolato l'attributo Link nel footer (link) ezobjectrelationlist
 * sovrascrivere le note del footer del sito se esiste ed è popolato l'attributo Note per il footer (note_footer) ezxmlblock

Note:
 * se viene impostato il logo di area, il nome del sito compare nella barra in alto (vedi /design/designitalia/templates/header/service.tpl) e non viene sovrascritto il logo del footer

Esempio in https://compa.fvg.it/desita/NextPA