### PR TITLE
add cross-var on build:css script

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "scripts": {
     "build:resources": "shx cp -r ita-web-toolkit/src/vendor design/designitalia/javascript/ && shx cp -r ita-web-toolkit/src/icons design/designitalia/stylesheets/icons",
-    "build:css": "cross-var shx cp themes/$npm_package_config_theme/index.css ./index.css && suitcss -m -c .postcss.js index.css design/designitalia/stylesheets/build_$npm_package_config_theme.css",
+    "build:css": "cross-var shx cp themes/$npm_package_config_theme/index.css ./index.css && cross-var suitcss -m -c .postcss.js index.css design/designitalia/stylesheets/build_$npm_package_config_theme.css",
     "watch:css": "cross-var suitcss -w -c .postcss.js index.css design/designitalia/stylesheets/build_$npm_package_config_theme.css",
     "build:js": "cross-env WEBPACK_ENV=build webpack",
     "watch:js": "cross-env WEBPACK_ENV=dev webpack --display-modules --progress --colors --watch",


### PR DESCRIPTION
aggiunto cross-var allo script "build:css" per renderlo compatibile con tutti i sistemi operativi